### PR TITLE
Change how collected appearances are stored

### DIFF
--- a/transmogTip/transmogTip.toc
+++ b/transmogTip/transmogTip.toc
@@ -1,5 +1,5 @@
 ## Interface: 30300
 ## Title: transmogTip
 ## Notes: Adds Transmog collection tooltips
-## SavedVariablesPerCharacter: TransmogTipList
+## SavedVariables: TransmogTipList
 core.lua


### PR DESCRIPTION
The AzerothCore mod mod-transmog stores appearances account-wide so it doesn't make sense for the addon to store data for each character seperately.